### PR TITLE
Add initial code on coding conventions

### DIFF
--- a/coding-conventions.md
+++ b/coding-conventions.md
@@ -1,0 +1,35 @@
+# Coding conventions
+
+The following is a list of conventions we follow when working in the [fcp-sfc-core] (https://github.com/DEFRA/fcp-sfd-core) repositories.
+
+- [File names](#file-names)
+- [Functions](#functions)
+
+## File names
+
+All file names should be [kebab-case] (https://www.freecodecamp.org/news/snake-case-vs-camel-case-vs-pascal-case-vs-kebab-case-whats-the-difference/#kebab-case), for example `awesome-people.js`
+
+To ensure cross-platform compatibility file names should always be written in lower case. This includes the use of acronyms in the file name. For example `convert-to-csv.js`.
+
+Unit test files should be the same as the thing being tested with `.test` added to the end, for example `thing.test.js`. The `test/` folder structure should mirror the `src/` folder.
+
+## Functions
+
+We define our functions as arrow functions expressions.
+
+```javascript
+// Do this! - Arrow function expression
+const helloWorld = (data) => {
+  returns 'Hello, world!'
+}
+
+// DON'T do this - Function declaration
+function helloWorld () {
+  return 'Hello, world!'
+}
+
+// OR this - Function expression
+const greet = function(name) {
+  return 'Hello, world!'
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-sfd-core",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Repo to support local development of Single Front Door Microservices",
   "type": "module",
   "main": "scripts/index.js",

--- a/service-compose/fcp-sfd-comms.yaml
+++ b/service-compose/fcp-sfd-comms.yaml
@@ -28,7 +28,7 @@ services:
       COMMS_REQUEST_QUEUE_URL: http://sqs.eu-west-2.127.0.0.1:4566/000000000000/fcp_sfd_comms_request
       COMMS_REQUEST_DEAD_LETTER_QUEUE_URL: http://sqs.eu-west-2.127.0.0.1:4566/000000000000/fcp_sfd_comms_request-deadletter
       SNS_ENDPOINT: http://localstack:4566
-      DAL_TOPIC_ARN: arn:aws:sns:eu-west-2:000000000000:fcp_sfd_data.fifo
+      COMM_EVENTS_TOPIC_ARN: arn:aws:sns:eu-west-2:000000000000:fcp_sfd_comm_events
       NOTIFY_API_KEY: ${NOTIFY_API_KEY}
     networks:
       - fcp-sfd

--- a/service-compose/fcp-sfd-data.yaml
+++ b/service-compose/fcp-sfd-data.yaml
@@ -25,7 +25,7 @@ services:
       NODE_ENV: development
       SQS_ENDPOINT: http://localstack:4566
       MONGO_URI: mongodb://mongodb:27017/
-      DATA_INGEST_QUEUE_URL: http://sqs.eu-west-2.127.0.0.1:4566/000000000000/fcp_sfd_data_ingest.fifo
-      DATA_INGEST_DEAD_LETTER_QUEUE_URL: http://sqs.eu-west-2.127.0.0.1:4566/000000000000/fcp_sfd_data_ingest_dlq.fifo
+      DATA_INGEST_QUEUE_URL: http://sqs.eu-west-2.127.0.0.1:4566/000000000000/fcp_sfd_data_ingest
+      DATA_INGEST_DEAD_LETTER_QUEUE_URL: http://sqs.eu-west-2.127.0.0.1:4566/000000000000/fcp_sfd_data_ingest-deadletter
     networks:
       - fcp-sfd


### PR DESCRIPTION
This adds a guide which documents the coding conventions we have noted down as a team. It is strongly encouraged that the team actively contribute to this guide as and when they think a new convention has become known.

Coding conventions help us maintain consistency across our SFD code bases, making it easier to read, understand and review each other's work. This shared set of conventions will help us onboard new team members and support the projects for long-term maintainability.