### PR TITLE
Add fcp-sfd-frontend-internal Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For new software developers joining the SFD team, there is an [onboarding guide]
 | [fcp-sfd-comms](https://github.com/defra/fcp-sfd-comms) | Customer | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
 | [fcp-sfd-data](https://github.com/defra/fcp-sfd-data) | Customer | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-data&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-data) |
 | [fcp-sfd-frontend](https://github.com/defra/fcp-sfd-frontend) | Customer | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-frontend&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-frontend) |
+| [fcp-sfd-frontend-internal](https://github.com/defra/fcp-sfd-frontend-internal) | Customer | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-frontend-internal&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-frontend-internal) |
 
 ## Local Development
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 include:
   - service-compose/fcp-sfd-messaging-gateway.yaml
   - service-compose/fcp-sfd-frontend.yaml
+  - service-compose/fcp-sfd-frontend-internal.yaml
   - service-compose/fcp-sfd-data.yaml
   - service-compose/fcp-sfd-comms.yaml
 services:
@@ -21,6 +22,7 @@ services:
       - ../fcp-sfd-data/compose/start-localstack.sh:/etc/localstack/init/ready.d/setup-fcp-sfd-data.sh
       - ../fcp-sfd-comms/compose/start-localstack.sh:/etc/localstack/init/ready.d/setup-fcp-sfd-comms.sh
       - ../fcp-sfd-frontend/compose/start-localstack.sh:/etc/localstack/init/ready.d/setup-fcp-sfd-frontend.sh
+      - ../fcp-sfd-frontend-internal/compose/start-localstack.sh:/etc/localstack/init/ready.d/setup-fcp-sfd-frontend-internal.sh
       - ../fcp-sfd-messaging-gateway/compose/start-localstack.sh:/etc/localstack/init/ready.d/setup-fcp-sfd-messaging-gateway.sh
     healthcheck:
       test:

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,8 +21,6 @@ services:
       - ${TMPDIR:-/tmp}/localstack:/var/lib/localstack
       - ../fcp-sfd-data/compose/start-localstack.sh:/etc/localstack/init/ready.d/setup-fcp-sfd-data.sh
       - ../fcp-sfd-comms/compose/start-localstack.sh:/etc/localstack/init/ready.d/setup-fcp-sfd-comms.sh
-      - ../fcp-sfd-frontend/compose/start-localstack.sh:/etc/localstack/init/ready.d/setup-fcp-sfd-frontend.sh
-      - ../fcp-sfd-frontend-internal/compose/start-localstack.sh:/etc/localstack/init/ready.d/setup-fcp-sfd-frontend-internal.sh
       - ../fcp-sfd-messaging-gateway/compose/start-localstack.sh:/etc/localstack/init/ready.d/setup-fcp-sfd-messaging-gateway.sh
     healthcheck:
       test:

--- a/onboarding-guide/useful-links.md
+++ b/onboarding-guide/useful-links.md
@@ -3,9 +3,7 @@ Below is a list of links that are useful to onboarding new software developers t
 
 - [fcp-sfd-core](https://github.com/defra/fcp-fd-core): Local development support for orchestrating all Single Front Door microservices.
 - [Defra ID Test Data](https://eaflood.atlassian.net/wiki/spaces/VVAHWR/pages/4329538112/DEFRA+ID+Test+Data): Mock CRNs and passwords that can be used for signing into the SFD via Defra Identity when `DEFRA_ID_ENABLED` is set to `true`.
-- [Single Front Door Production Board (Jira)](https://eaflood.atlassian.net/jira/software/projects/SFDP/boards/1959): Where all SFD production tickets are tracked.
-- [Single Front Door Release Board (Jira)](https://eaflood.atlassian.net/jira/software/projects/SFDR/boards/2552): Where all SFD release tickets are tracked.
-- [Single Front Door Explore Board (Jira)](https://eaflood.atlassian.net/jira/software/projects/SFDE/boards/2551): Where all SFD explore tickets are tracked.
-- [Single Front Door Confluence (Tech/Development)](https://eaflood.atlassian.net/wiki/spaces/SFD/pages/5031591957/SFD+Tech): Where the development team shares all development/technical write ups. All information relating to previous spikes, general development guides, a list of all the ports used for local development etc. can be found within this Confluence space.
+- [Single Front Door Jira Board](https://eaflood.atlassian.net/browse/SFD2): Where all SFD tickets are tracked.
+- [Single Front Door Confluence (Tech/Development)](https://eaflood.atlassian.net/wiki/spaces/SFD/pages/5031591957/Development): Where the development team shares all development/technical write ups. All information relating to previous spikes, general development guides, a list of all the ports used for local development etc. can be found within this Confluence space.
 - [Single Front Door Development Mural Board](https://app.mural.co/t/coredefra2548/m/coredefra2548/1721160148925/0b93a34e740904ce2ddd38b3e1500115faeaaa50?sender=u44a46391b2aa71218c732390): Dedicated Mural board for the SFD development team to use for planning, diagrams etc.
-- [Development Onboarding](https://eaflood.atlassian.net/wiki/spaces/SFD/folder/5334007858): guides for new developers joining the team that are stored on our Confluence space.
+- [Development Onboarding](https://eaflood.atlassian.net/wiki/spaces/SFD/pages/5031034982/Onboarding+guide): guides for new developers joining the team that are stored on our Confluence space.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-sfd-core",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Repo to support local development of Single Front Door Microservices",
   "type": "module",
   "main": "scripts/index.js",

--- a/service-compose/fcp-sfd-frontend-internal.yaml
+++ b/service-compose/fcp-sfd-frontend-internal.yaml
@@ -1,0 +1,28 @@
+services:
+  fcp-sfd-frontend-internal:
+    build:
+      context: ../../fcp-sfd-frontend-internal
+      target: development
+    image: fcp-sfd-frontend-internal-development
+    container_name: fcp-sfd-frontend-internal-development
+    ports:
+      - "3006:3006"
+    links:
+      - "localstack:localstack"
+      - "redis:redis"
+    depends_on:
+      localstack:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    volumes:
+      - ../../fcp-sfd-frontend-internal/src:/home/node/src
+      - ../../fcp-sfd-frontend-internal/package.json:/home/node/package.json
+    env_file:
+      - ../.env
+    environment:
+      PORT: 3006
+      NODE_ENV: development
+      SQS_ENDPOINT: http://localstack:4566
+    networks:
+      - fcp-sfd


### PR DESCRIPTION
This PR adds the fcp-sfd-frontend-internal service to the core development environment.

**Changes**
- Added fcp-sfd-frontend-internal service configuration in service-compose/
- Included the service in the main compose.yaml
- Removed non-existent localstack volume mount for fcp-sfd-frontend (frontend services don't require SQS/SNS setup)
- Updated README with fcp-sfd-frontend-internal repository link
- Updated onboarding guide links
- Bumped version to 2.6.0