### PR TITLE
chore: standardise .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 git-tag-version=false
-min-release-age=7
 save-exact=true
+ignore-scripts=true
+min-release-age=7


### PR DESCRIPTION
- Standardise .npmrc with git-tag-version=false, save-exact=true, ignore-scripts=true, min-release-age=7